### PR TITLE
Multiline extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 GNU GetText translation tools for Borland Delphi and Borland C++ Builder
 
+
+
+2026-09-09 Added support for multi-line text (Lines.Strings) as one translation item,
+           as opposed to Items.Strings, which are translated as separate items
+		   
+	Note: 
+	- Delphi 6 and up : Use gnugettext.pas version in \dxgettext\sample\    
+	- Delphi 5 version of gnugettext.pas is not updated               
+	- Freepascal version of gnugettext.pas is not updated            
+
 2025-04-01 Sync with trunk r182 https://sourceforge.net/p/dxgettext/code/182/log/?path=/trunk
 
 2023-04-20 Fork from https://sourceforge.net/projects/dxgettext/

--- a/dxgettext/dxgettext/xgettext.pas
+++ b/dxgettext/dxgettext/xgettext.pas
@@ -2178,23 +2178,21 @@ begin
   if (aInstanceName = '') or (aFilename = '') or (FFormInstances.Count = 0) then
     Exit;
   aInstanceName := LowerCase(aInstanceName);
-  p := 0;
   for i := 0 to FFormInstances.Count-1 do begin
-    if lowercase(RightStr(FFormInstances[i], Length(aInstancename))) = aInstancename then
-      p := Length(aInstancename) -1
-    else
-      continue;
-    if p > 0 then begin
-      filenamepart := LeftStr(FFormInstances[i], Length(FFormInstances[i])-p-2);
-      instancenamepart := lowercase(RightStr(FFormInstances[i], p+1));
-      {$ifdef mswindows}
-      if (AnsiLowercase(filenamepart) = AnsiLowercase(aFilename))
-      {$else}
-      if (filenamepart = aFilename)
-      {$endif}
-      and (instancenamepart = aInstanceName) then begin
-        Result := true;
-        exit;
+    if lowercase(RightStr(FFormInstances[i], Length(aInstancename))) = aInstancename then begin
+      p := Length(aInstancename) -1;
+      if p > 0 then begin
+        filenamepart := LeftStr(FFormInstances[i], Length(FFormInstances[i])-p-2);
+        instancenamepart := lowercase(RightStr(FFormInstances[i], p+1));
+        {$ifdef mswindows}
+        if (AnsiLowercase(filenamepart) = AnsiLowercase(aFilename))
+        {$else}
+        if (filenamepart = aFilename)
+        {$endif}
+        and (instancenamepart = aInstanceName) then begin
+          Result := true;
+          exit;
+        end;
       end;
     end;
   end;

--- a/dxgettext/dxgettext/xgettext.pas
+++ b/dxgettext/dxgettext/xgettext.pas
@@ -728,7 +728,7 @@ var
   fs,
   src: TStream;
   mem: TMemoryStream;
-  line, lastline:string;
+  line, lastline: string;
   s: string;
   i:integer;
   indent: integer;
@@ -737,19 +737,21 @@ var
   scope: TStringList;
   propertyname: string;
   multilinevalue: boolean;
+  multilinetext: boolean;  // true for Lines.Strings (one single text block)
   mvalue: string;
   p1, p2, p3: integer;
   pClassname: integer;
   c:char;
   classnamepart: string;
-  linechar:char;
+  linechar: char;
   currentclassname: string;
   classnames: TStringList;
   instancenames: TStringList;
-  excludeclass:boolean;
-  excludeinstance:boolean;
-  collectionlevel:integer; // will be increased which each occurence of a collection, in order to recognize nested collections
-  collectionpropertyname:string; // will be the propertyname of the highest-level collection property
+  excludeclass: boolean;
+  excludeinstance: boolean;
+  collectionlevel: integer; // will be increased which each occurence of a collection, in order to recognize nested collections
+  collectionpropertyname: string; // will be the propertyname of the highest-level collection property
+
 
   procedure AddEntry(const aValue:string);
   var
@@ -803,6 +805,7 @@ begin
       collectionpropertyname := '';
       multilinevalue := false;
       collectionlevel := 0;
+      multilinetext := false;
       while true do begin
         // Get next line and check it out
         lastline := line;
@@ -893,7 +896,10 @@ begin
         // Check for changes in scope
         if (indent < scope.Count) and multilinevalue then begin
           multilinevalue := false;
-          AddEntry(mvalue);
+          if not multilinetext then begin
+            AddEntry(mvalue);
+            mvalue := '';
+          end;
           scope.Delete(scope.count - 1);
         end;
         while indent < scope.Count do begin
@@ -905,7 +911,6 @@ begin
           if p = 0 then s := lastline else s := copy(lastline, p + 1, maxint);
           p := pos(':', s);
           multilinevalue := true;
-          mvalue := '';
           if p = 0 then s := '' else s := copy(s, 1, p - 1);
         end;
         while indent > scope.Count do begin
@@ -923,29 +928,47 @@ begin
 
         // Extract property name if the line contains such one
         if (p <> 0) and (p < p3) then begin
+          // We are reading a new property:
+          //   flush remaining multilinetext first, so it gets noted on the correct propertyname
+          if mvalue <> '' then begin
+            AddEntry(mvalue);
+            mvalue := '';
+          end;
+
           propertyname := trim(copy(line, 1, p - 1));
-          // is we're in a collection (and it's the highest level if there are nested collections), remember the property name of that collection
+          // if we're in a collection (and it's the highest level if there are nested collections), remember the property name of that collection
           if (collectionlevel = 1) and (collectionpropertyname = '') then
             collectionpropertyname := propertyname;
-          multilinevalue := false;
+
+          multilinetext := lowercase(propertyname) = 'lines.strings'; // The property 'Lines.Strings' we will always
+          multilinevalue := false;                                   //  interpret as -one- item for translation
         end;
 
         // Extract string, if the line contains such one
         if p3 <> maxint then begin
           delete(line, 1, p3 - 1);
           extractstring(line, s);
-          if multilinevalue then begin
+          if multilinevalue or multilinetext then begin
             mvalue := mvalue + s;
             if trim(line) <> '+' then begin
-              AddEntry(mvalue);
-              mvalue:='';
+              if multilinetext then
+                mvalue := mvalue + #13#10
+              else begin
+                AddEntry(mvalue);
+                mvalue := '';
+              end;
             end;
           end else begin
             AddEntry(s);
           end;
         end;
-      end;
+      end;  { while true - reading lines }
     finally
+      // EOF: flush a remaining multilinetext
+      if mvalue <> '' then begin
+        AddEntry(mvalue);
+        mvalue := '';
+      end;
       FreeAndNil(scope);
       FreeAndNil(classnames);
     end;

--- a/dxgettext/sample/gnugettext.pas
+++ b/dxgettext/sample/gnugettext.pas
@@ -2565,82 +2565,94 @@ var
   {$endif dx_StringList_has_OwnsObjects}
 begin
   if sl.Count > 0 then begin
-    {$ifdef dx_StringList_has_OwnsObjects}
-    // From D2009 onward, the TStringList class has an OwnsObjects property, just like
-    // TObjectList has. This means that if we call Clear on the given
-    // list in the sl parameter, we could destroy the objects it contains.
-    // To avoid this we must disable OwnsObjects while we replace the strings, but
-    // only if sl is a TStringList instance and if using Delphi 2009 or later.
-    originalOwnsObjects := False; // avoid warning
-    if sl is TStringList then
-      slAsTStringList := TStringList(sl)
+
+    if sl.ClassName = 'TMemoStrings' then
+    begin
+      // Text from memo's we translate as a whole
+      if (TextDomain = '') or (TextDomain = DefaultTextDomain) then
+        sl.Text := ComponentGettext(sl.Text, Self)
+      else
+        sl.Text := dgettext(TextDomain,sl.Text);
+    end
     else
-      slAsTStringList := nil;
-    {$endif dx_StringList_has_OwnsObjects}
+    begin
+      {$ifdef dx_StringList_has_OwnsObjects}
+      // From D2009 onward, the TStringList class has an OwnsObjects property, just like
+      // TObjectList has. This means that if we call Clear on the given
+      // list in the sl parameter, we could destroy the objects it contains.
+      // To avoid this we must disable OwnsObjects while we replace the strings, but
+      // only if sl is a TStringList instance and if using Delphi 2009 or later.
+      originalOwnsObjects := False; // avoid warning
+      if sl is TStringList then
+        slAsTStringList := TStringList(sl)
+      else
+        slAsTStringList := nil;
+      {$endif dx_StringList_has_OwnsObjects}
 
-    sl.BeginUpdate;
-    try
-      tempSL:=TStringList.Create;
+      sl.BeginUpdate;
       try
-        // don't use Assign here as it will propagate the Sorted property (among others)
-        // in versions of Delphi from Delphi XE onward
-        tempSL.AddStrings(sl);
+        tempSL:=TStringList.Create;
+        try
+          // don't use Assign here as it will propagate the Sorted property (among others)
+          // in versions of Delphi from Delphi XE onward
+          tempSL.AddStrings(sl);
 
-        for i:=0 to tempSL.Count-1 do begin
-          line:=tempSL.Strings[i];
-          if line<>'' then
-            if (TextDomain = '') or (TextDomain = DefaultTextDomain) then
-              tempSL.Strings[i]:=ComponentGettext(line, Self)
-            else
-              tempSL.Strings[i]:=dgettext(TextDomain,line);
-        end;
-
-        //DH Fix 2013-09-19: Only refill sl if changed
-        if sl.Text<>tempSL.Text then
-        begin
-          {$ifdef dx_StringList_has_OwnsObjects}
-          if Assigned(slAsTStringList) then begin
-            originalOwnsObjects := slAsTStringList.OwnsObjects;
-            slAsTStringList.OwnsObjects := False;
+          for i:=0 to tempSL.Count-1 do begin
+            line:=tempSL.Strings[i];
+            if line<>'' then
+              if (TextDomain = '') or (TextDomain = DefaultTextDomain) then
+                tempSL.Strings[i]:=ComponentGettext(line, Self)
+              else
+                tempSL.Strings[i]:=dgettext(TextDomain,line);
           end;
-          {$endif dx_StringList_has_OwnsObjects}
-          try
-            {$ifdef dx_StringList_has_OwnsObjects}
-            if Assigned(slAsTStringList) and slAsTStringList.Sorted then
-            begin
-              // TStringList doesn't release the objects in PutObject, so we use this to get
-              // sl.Clear to not destroy the objects in classes that inherit from TStringList
-              // but do a ClearObject in Clear.
-              //
-              // todo: Check whether this should be
-              //   if sl is TStringList then
-              // instead.
-              if sl.ClassType <> TStringList then
-                for I := 0 to sl.Count - 1 do
-                  sl.Objects[I] := nil;
 
-              // same here, we don't use assign because we don't want to modify the properties of the orignal string list
-              sl.Clear;
-              sl.AddStrings(tempSL);
-            end
-            else
-            {$endif dx_StringList_has_OwnsObjects}
-            begin
-              for i := 0 to sl.Count - 1 do
-                sl[i] := tempSL[i];
+          //DH Fix 2013-09-19: Only refill sl if changed
+          if sl.Text<>tempSL.Text then
+          begin
+            {$ifdef dx_StringList_has_OwnsObjects}
+            if Assigned(slAsTStringList) then begin
+              originalOwnsObjects := slAsTStringList.OwnsObjects;
+              slAsTStringList.OwnsObjects := False;
             end;
-          finally
-            {$ifdef dx_StringList_has_OwnsObjects}
-            if Assigned(slAsTStringList) then
-              slAsTStringList.OwnsObjects := originalOwnsObjects;
             {$endif dx_StringList_has_OwnsObjects}
+            try
+              {$ifdef dx_StringList_has_OwnsObjects}
+              if Assigned(slAsTStringList) and slAsTStringList.Sorted then
+              begin
+                // TStringList doesn't release the objects in PutObject, so we use this to get
+                // sl.Clear to not destroy the objects in classes that inherit from TStringList
+                // but do a ClearObject in Clear.
+                //
+                // todo: Check whether this should be
+                //   if sl is TStringList then
+                // instead.
+                if sl.ClassType <> TStringList then
+                  for I := 0 to sl.Count - 1 do
+                    sl.Objects[I] := nil;
+
+                // same here, we don't use assign because we don't want to modify the properties of the orignal string list
+                sl.Clear;
+                sl.AddStrings(tempSL);
+              end
+              else
+              {$endif dx_StringList_has_OwnsObjects}
+              begin
+                for i := 0 to sl.Count - 1 do
+                  sl[i] := tempSL[i];
+              end;
+            finally
+              {$ifdef dx_StringList_has_OwnsObjects}
+              if Assigned(slAsTStringList) then
+                slAsTStringList.OwnsObjects := originalOwnsObjects;
+              {$endif dx_StringList_has_OwnsObjects}
+            end;
           end;
+        finally
+          FreeAndNil (tempSL);
         end;
       finally
-        FreeAndNil (tempSL);
+        sl.EndUpdate;
       end;
-    finally
-      sl.EndUpdate;
     end;
   end;
 end;

--- a/dxgettext/sample/gnugettext.pas
+++ b/dxgettext/sample/gnugettext.pas
@@ -19,6 +19,7 @@ unit gnugettext;
 (*                Thomas Mueller (dummzeuch)                  *)
 (*                Olivier Sannier (obones)                    *)
 (*                Luebbe Onken (LO)                           *)
+(*                Michiel Spoor (gimbal2000)                  *)
 (*                                                            *)
 (*  See http://dxgettext.po.dk/ for more information          *)
 (*                                                            *)


### PR DESCRIPTION
Added support for extraction and translation of the 'Lines.Strings' property (TMemo etc) into one single item, containing a multi-line text.
Properties with the name 'Items.Strings' are still extracted as separate items.